### PR TITLE
[argocd] Support AnalysisTemplate

### DIFF
--- a/argocd/wait-for-resource.sh
+++ b/argocd/wait-for-resource.sh
@@ -46,6 +46,11 @@ wait-for-resource() {
       return 0
       ;;
 
+    AnalysisTemplate)
+      echo "Skipping waiting for Service"
+      return 0
+      ;;
+
     *)
       echo "Unknown resource to wait for: ${kind}"
       return 1


### PR DESCRIPTION
The AnalysisTemplates can be used to define integration tests to canary analysis.

Add support for these kind of resources